### PR TITLE
DEV-3292 Modularize and Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Start from the latest golang base image
+FROM golang:1.19 as builder
+
+WORKDIR /build
+
+# Copy go mod and sum files
+COPY go.mod go.sum ./
+
+# Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed
+RUN go mod download
+
+# Copy the source from the current directory to the Working Directory inside the container
+COPY . .
+
+# Build the Go app - Generate heic2jpg binary
+RUN CGO_ENABLED=1 go build -ldflags='-extldflags=-static' -a -o ./deploy/heic2jpg ./heic2jpg
+
+FROM scratch
+# Copy the binary from the builder stage
+COPY --from=builder /build/deploy/heic2jpg /
+ENTRYPOINT [ "/heic2jpg" ]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Intel and ARM supported
 
 ## Install
 
-```go get github.com/adrium/goheif```
+```go get github.com/connectRN/goheif```
 
 - Code Sample
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/connectRN/goheif
+
+go 1.19
+
+require github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd h1:CmH9+J6ZSsIjUK3dcGsnCnO41eRBOnY12zwkn5qVwgc=
+github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=

--- a/goheif.go
+++ b/goheif.go
@@ -8,8 +8,8 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/adrium/goheif/heif"
-	"github.com/adrium/goheif/libde265"
+	"github.com/connectRN/goheif/heif"
+	"github.com/connectRN/goheif/libde265"
 )
 
 // SafeEncoding uses more memory but seems to make

--- a/heic2jpg/main.go
+++ b/heic2jpg/main.go
@@ -66,6 +66,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Prevent frequent crashes when running in linux
+	goheif.SafeEncoding = true
+
 	fin, fout := flag.Arg(0), flag.Arg(1)
 	fi, err := os.Open(fin)
 	if err != nil {

--- a/heic2jpg/main.go
+++ b/heic2jpg/main.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/adrium/goheif"
+	"github.com/connectRN/goheif"
 )
 
 // Skip Writer for exif writing

--- a/heif/heif.go
+++ b/heif/heif.go
@@ -27,7 +27,7 @@ import (
 	"io"
 	"log"
 
-	"github.com/adrium/goheif/heif/bmff"
+	"github.com/connectRN/goheif/heif/bmff"
 )
 
 // File represents a HEIF file.


### PR DESCRIPTION
- Convert to be a go module under github.com/connectRN/goheif
- Prevent frequent crashes when running in linux
- Build a docker container containing a statically compiled binary of the heif2jpg utility.